### PR TITLE
feat: add basic csv

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -8,7 +8,7 @@ layout:
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
-projectName: operator2
+projectName: operator
 repo: github.com/janus-idp/operator
 resources:
 - api:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/config/manifests/bases/operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/operator.clusterserviceversion.yaml
@@ -1,0 +1,43 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+  name: operator.v0.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions: {}
+  description: foo
+  displayName: Janus IDP
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      deployments: null
+    strategy: ""
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - foo
+  - bar
+  links:
+  - name: Operator
+    url: https://operator.domain
+  maintainers:
+  - email: foo@bar.baz
+    name: foo
+  maturity: alpha
+  provider:
+    name: foo
+    url: bar
+  version: 0.0.0


### PR DESCRIPTION
Basic CSV placeholder. This enables a non-interactive `make bundle` which produces:

- `bundle.Dockerfile`
- `bundle` folder


cc @nickboldt 


<details><summary>
<code>make bundle</code> creates a <code>bundle/manifests/charts.janus-idp.io_backstages.yaml</code>:

</summary>
<p>

```
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  creationTimestamp: null
  name: backstages.charts.janus-idp.io
spec:
  group: charts.janus-idp.io
  names:
    kind: Backstage
    listKind: BackstageList
    plural: backstages
    singular: backstage
  scope: Namespaced
  versions:
  - name: v1alpha1
    schema:
      openAPIV3Schema:
        description: Backstage is the Schema for the backstages API
        properties:
          apiVersion:
            description: 'APIVersion defines the versioned schema of this representation
              of an object. Servers should convert recognized schemas to the latest
              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
            type: string
          kind:
            description: 'Kind is a string value representing the REST resource this
              object represents. Servers may infer this from the endpoint the client
              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
            type: string
          metadata:
            type: object
          spec:
            description: Spec defines the desired state of Backstage
            type: object
            x-kubernetes-preserve-unknown-fields: true
          status:
            description: Status defines the observed state of Backstage
            type: object
            x-kubernetes-preserve-unknown-fields: true
        type: object
    served: true
    storage: true
    subresources:
      status: {}
status:
  acceptedNames:
    kind: ""
    plural: ""
  conditions: null
  storedVersions: null
```

</p>
</details> 